### PR TITLE
    Update .gitignore to exclude soljson-v*.wasm files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 soljson-v*.js
+soljson-v*.wasm


### PR DESCRIPTION
    Added a new rule to ignore WebAssembly files matching soljson-v*.wasm. This prevents unnecessary tracking of build artifacts in the repository.