### PR TITLE
ft/add-status-bar-copy-address

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useDeploymentStore } from '@/stores/deploymentStore';
 import { Separator } from '@/components/ui/separator';
+import { Copy } from 'lucide-react';
+import { toast } from 'sonner';
 
 const StatusBar: React.FC = () => {
   const {
@@ -87,9 +89,39 @@ const StatusBar: React.FC = () => {
 
             <div className="flex items-center space-x-1">
               <span className="text-xs">Account:</span>
-              <span className="font-mono text-xs font-medium text-foreground">
+              <span
+                className="font-mono text-xs font-medium text-foreground cursor-pointer"
+                title="Click to copy address"
+                onClick={() => {
+                  void navigator.clipboard.writeText(account)
+                    .then(() => {
+                      toast.success('Address copied to clipboard');
+                    })
+                    .catch(() => {
+                      toast.error('Failed to copy address');
+                    });
+                }}
+              >
                 {`${account.slice(0, 6)}...${account.slice(-4)}`}
               </span>
+              <button
+                type="button"
+                aria-label="Copy address"
+                title="Copy address"
+                className="p-0.5 hover:text-foreground/90"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void navigator.clipboard.writeText(account)
+                    .then(() => {
+                      toast.success('Address copied to clipboard');
+                    })
+                    .catch(() => {
+                      toast.error('Failed to copy address');
+                    });
+                }}
+              >
+                <Copy className="h-3.5 w-3.5" />
+              </button>
             </div>
           </>
         )}


### PR DESCRIPTION
## Summary

This Pull Request introduces a feature that allows users to copy an account address by interacting with a clickable span or button in the StatusBar component. It also integrates visual and toast notifications to confirm the action's success or failure.


**Key Changes**

- **Added clipboard copy functionality:** Users can copy the account address by clicking on a span or a dedicated button.
- **Integrated lucide-react and sonner libraries** for UI and success/error toast notifications.
- **Updated styles and attributes:** Introduced cursor behavior, interactive titles, and improved UI responsiveness for the copy functionality.