### PR TITLE
fix/renaming-filenames

### DIFF
--- a/src/components/FileExplorer/FileExplorer.tsx
+++ b/src/components/FileExplorer/FileExplorer.tsx
@@ -52,6 +52,7 @@ const FileExplorer: React.FC<FileExplorerProps> = ({ className = '' }) => {
 
   const [searchQuery, setSearchQuery] = useState('');
   const [clipboardItem, setClipboardItem] = useState<ClipboardItem | null>(null);
+  const [renamingFilePath, setRenamingFilePath] = useState<string | null>(null);
 
   // Fetch Git status when Git is initialized or files change
   useEffect(() => {
@@ -224,6 +225,7 @@ const FileExplorer: React.FC<FileExplorerProps> = ({ className = '' }) => {
       const parentPath = oldPath.substring(0, oldPath.lastIndexOf('/')) || '/';
       const newPath = parentPath === '/' ? `/${newName}` : `${parentPath}/${newName}`;
       renameFile(oldPath, newPath);
+      setRenamingFilePath(null); // Clear rename trigger after completion
     },
     [renameFile],
   );
@@ -442,6 +444,7 @@ const FileExplorer: React.FC<FileExplorerProps> = ({ className = '' }) => {
               expandedFolders={expandedFolders}
               selectedFiles={selectedFiles}
               toggleFolder={toggleFolder}
+              triggerRename={renamingFilePath === file.path}
             />
           ))}
         </div>
@@ -469,8 +472,8 @@ const FileExplorer: React.FC<FileExplorerProps> = ({ className = '' }) => {
           onCreateFolder={(parentPath) => handleCreateNew('folder', parentPath)}
           onDelete={handleDelete}
           onRename={(filePath) => {
-            // Trigger rename mode in FileTreeItem
-            // This is handled by the FileTreeItem component itself
+            setRenamingFilePath(filePath);
+            setContextMenu(null);
           }}
           onCopy={handleCopy}
           onCut={handleCut}

--- a/src/components/FileExplorer/FileTreeItem.tsx
+++ b/src/components/FileExplorer/FileTreeItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import type { FileNode } from '@/types';
 import { LucideFilePlus, LucideFolderPlus, LucidePencil } from 'lucide-react';
 import { Button } from '@/components/ui/button.tsx';
@@ -108,6 +108,7 @@ interface FileTreeItemProps {
   expandedFolders: Set<string>;
   selectedFiles: string[];
   toggleFolder: (path: string) => void;
+  triggerRename?: boolean;
 }
 
 const FileTreeItem: React.FC<FileTreeItemProps> = ({
@@ -129,9 +130,21 @@ const FileTreeItem: React.FC<FileTreeItemProps> = ({
   expandedFolders,
   selectedFiles,
   toggleFolder,
+  triggerRename,
 }) => {
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(file.name);
+
+  // Trigger rename mode when requested from context menu
+  useEffect(() => {
+    if (triggerRename) {
+      setIsRenaming(true);
+      setRenameValue(file.name);
+    } else {
+      // Reset rename mode when triggerRename becomes false
+      setIsRenaming(false);
+    }
+  }, [triggerRename, file.name, file.path]);
 
   const handleRenameSubmit = useCallback(
     (event: React.FormEvent) => {
@@ -152,8 +165,11 @@ const FileTreeItem: React.FC<FileTreeItemProps> = ({
   const handleRenameKeyDown = useCallback((event: React.KeyboardEvent) => {
     if (event.key === 'Escape') {
       setIsRenaming(false);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      handleRenameSubmit(event as any);
     }
-  }, []);
+  }, [handleRenameSubmit]);
 
   return (
     <>
@@ -312,6 +328,7 @@ const FileTreeItem: React.FC<FileTreeItemProps> = ({
                   selectedFiles={selectedFiles}
                   getChildren={getChildren}
                   toggleFolder={toggleFolder}
+                  triggerRename={false}
                 />
               ))}
 


### PR DESCRIPTION
## Summary

This Pull Request introduces a feature enabling renaming files or folders in the file explorer, initiated through context menu interaction. It focuses on managing state for rename operations and handling corresponding UI behavior.

**Main changes**

- Added renaming state in FileExplorer.tsx:
    - Introduced a renamingFilePath state to track the file or folder being renamed.
    - Enhanced the onRename handler to trigger the rename mode and clear the context menu.
    - Updated logic to signal the FileTreeItem component when a rename is triggered.

- Enhanced FileTreeItem.tsx for rename functionality:
    - Added triggerRename prop to enable rename mode programmatically.
    - Integrated a useEffect hook to handle rename state transitions upon context menu interactions.
    - Enhanced keyboard interactions to handle Enter key submission and Escape key cancellation during renaming.

This PR primarily simplifies file and folder renaming workflows for improved usability.